### PR TITLE
feat: make worker respond to term and task state

### DIFF
--- a/internal/engine/clients/broker/broker.go
+++ b/internal/engine/clients/broker/broker.go
@@ -2,7 +2,13 @@ package broker
 
 import "context"
 
+type BrokerType string
+
+const (
+	Memory BrokerType = "memory"
+)
+
 type Broker interface {
-	Subscribe(ctx context.Context, callback func(ctx context.Context, data []byte) error, opts ...SubscribeOption) error
+	Subscribe(ctx context.Context, callback func(ctx context.Context, data []byte) error, opts ...SubscribeOption) (chan struct{}, error)
 	Publish(ctx context.Context, data []byte, opts ...PublishOption) error
 }

--- a/internal/engine/clients/runner/runner.go
+++ b/internal/engine/clients/runner/runner.go
@@ -2,6 +2,12 @@ package runner
 
 import "context"
 
+type RuntimeType string
+
+const (
+	Docker RuntimeType = "docker"
+)
+
 type Runner interface {
 	Start(ctx context.Context, opts ...StartOption) error
 	Stop(ctx context.Context, opts ...StopOption) error

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -4,20 +4,17 @@ import (
 	"time"
 )
 
-const (
-	// Pending is the initial state for every task
-	Pending State = iota
-	// Scheduled is the state once the coordinator has assigned a worker to the task
-	Scheduled
-	// Running is the state when a worker successfully starts the task
-	Running
-	// Completed is the state when the worker successfully completes the task
-	Completed
-	// Failed is the state when the worker has failed to start or complete the task
-	Failed
-)
+type State string
 
-type State int
+const (
+	Pending   State = "PENDING"
+	Scheduled State = "SCHEDULED"
+	Running   State = "RUNNING"
+	Cancelled State = "CANCELLED"
+	Stopped   State = "STOPPED"
+	Completed State = "COMPLETED"
+	Failed    State = "FAILED"
+)
 
 type Task struct {
 	ID            string    `json:"id"`


### PR DESCRIPTION
We are setting up a graceful shutdown of workers and implementing the ability for workers to manage tasks based on state. Some refactors to the in-memory broker and task state were required.