### PR TITLE
refactor: switch to 'scheduled' from 'pending'

### DIFF
--- a/internal/engine/clients/broker/queues.go
+++ b/internal/engine/clients/broker/queues.go
@@ -1,7 +1,7 @@
 package broker
 
 const (
-	PENDING   = "pending"
+	SCHEDULED = "scheduled"
 	STARTED   = "started"
 	COMPLETED = "completed"
 	FAILED    = "failed"

--- a/internal/engine/services/coordinator/service.go
+++ b/internal/engine/services/coordinator/service.go
@@ -64,13 +64,13 @@ func (s *Service) ScheduleTask(ctx context.Context, t *task.Task) (*task.Task, e
 	now := time.Now()
 
 	t.ID = strings.ReplaceAll(uuid.NewString(), "-", "")
-	t.State = task.Pending
+	t.State = task.Scheduled
 	t.ScheduledAt = &now
 
 	bs, _ := json.Marshal(t)
 
 	opts := []broker.PublishOption{
-		broker.PublishWithQueue(broker.PENDING),
+		broker.PublishWithQueue(broker.SCHEDULED),
 	}
 
 	if err := s.broker.Publish(ctx, bs, opts...); err != nil {

--- a/internal/engine/services/worker/service.go
+++ b/internal/engine/services/worker/service.go
@@ -20,7 +20,7 @@ type Service struct {
 
 func (s *Service) Start() error {
 	opts := []broker.SubscribeOption{
-		broker.SubscribeWithQueue(broker.PENDING),
+		broker.SubscribeWithQueue(broker.SCHEDULED),
 	}
 
 	exit, err := s.broker.Subscribe(context.Background(), s.handleTask, opts...)
@@ -46,7 +46,7 @@ func (s *Service) handleTask(ctx context.Context, data []byte) error {
 
 	started := time.Now()
 
-	t.State = task.Running
+	t.State = task.Started
 	t.StartedAt = &started
 
 	startedBs, _ := json.Marshal(t)

--- a/internal/task/domain.go
+++ b/internal/task/domain.go
@@ -7,9 +7,8 @@ import (
 type State string
 
 const (
-	Pending   State = "PENDING"
 	Scheduled State = "SCHEDULED"
-	Running   State = "RUNNING"
+	Started   State = "STARTED"
 	Cancelled State = "CANCELLED"
 	Stopped   State = "STOPPED"
 	Completed State = "COMPLETED"


### PR DESCRIPTION
Renaming instances of 'pending' to 'scheduled'.