### PR TITLE
refactor: use multiple connections for rabbit impl

### DIFF
--- a/internal/engine/clients/broker/errors.go
+++ b/internal/engine/clients/broker/errors.go
@@ -3,8 +3,9 @@ package broker
 import "errors"
 
 var (
-	ErrCreatingChannel = errors.New("failed to create channel")
-	ErrCreatingQueue   = errors.New("failed to create queue")
-	ErrSubscribing     = errors.New("failed to subscribe")
-	ErrPublishing      = errors.New("failed to publish")
+	ErrCreatingChannel     = errors.New("failed to create channel")
+	ErrCreatingQueue       = errors.New("failed to create queue")
+	ErrSettingMessageCount = errors.New("failed to set message count")
+	ErrSubscribing         = errors.New("failed to subscribe")
+	ErrPublishing          = errors.New("failed to publish")
 )


### PR DESCRIPTION
Refactors the RabbitMQ broker impl to use separate connections for subscribing and publishing. Additionally, introduces a QOS setting for consumers to better manage flow and prevent consumer overload.