### PR TITLE
refactor: use a shutdown channel instead of dockerRunner ctx

### DIFF
--- a/internal/engine/clients/runner/errors.go
+++ b/internal/engine/clients/runner/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrVolumeNotFound    = errors.New("volume not found")
 	ErrInvalidVolumeName = errors.New("invalid volume name")
 	ErrBadExitCode       = errors.New("bad exit code")
+	ErrRunnerClosing     = errors.New("runner is closing")
 )


### PR DESCRIPTION
Refactors the dockerRunner's shutdown mechanism to use an exit channel and sync.Once instead of a ctx.