### PR TITLE
fix: ensure we say we failed if we fail to create a vol

### DIFF
--- a/internal/engine/clients/broker/rabbit/broker.go
+++ b/internal/engine/clients/broker/rabbit/broker.go
@@ -118,6 +118,7 @@ func (b *rabbitBroker) Subscribe(ctx context.Context, callback func(ctx context.
 			}
 		}
 
+		// span
 		slog.ErrorContext(ctx, "subscriber failed to connect after max attempts", "queue", options.Queue, "maxAttempts", maxAttempts)
 	}()
 


### PR DESCRIPTION
Addresses a bug where tasks were not correctly marked as failed when a volume creation operation failed.