### PR TITLE
refactor: use mount type instead of strings

### DIFF
--- a/internal/engine/clients/runner/docker/runner.go
+++ b/internal/engine/clients/runner/docker/runner.go
@@ -52,17 +52,12 @@ func (r *dockerRunner) Run(ctx context.Context, opts ...runner.RunOption) (strin
 
 	var mounts []mount.Mount
 
-	for _, v := range options.Volumes {
-		vol := strings.Split(v, ":")
-		if len(vol) != 2 {
-			return "", runner.ErrInvalidVolumeName
-		}
-		mount := mount.Mount{
+	for _, m := range options.Mounts {
+		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeVolume,
-			Source: vol[0],
-			Target: vol[1],
-		}
-		mounts = append(mounts, mount)
+			Source: m["source"],
+			Target: m["target"],
+		})
 	}
 
 	hc := container.HostConfig{

--- a/internal/engine/clients/runner/errors.go
+++ b/internal/engine/clients/runner/errors.go
@@ -3,9 +3,8 @@ package runner
 import "errors"
 
 var (
-	ErrPullingImage      = errors.New("failed to pull image")
-	ErrVolumeNotFound    = errors.New("volume not found")
-	ErrInvalidVolumeName = errors.New("invalid volume name")
-	ErrBadExitCode       = errors.New("bad exit code")
-	ErrRunnerClosing     = errors.New("runner is closing")
+	ErrPullingImage   = errors.New("failed to pull image")
+	ErrVolumeNotFound = errors.New("volume not found")
+	ErrBadExitCode    = errors.New("bad exit code")
+	ErrRunnerClosing  = errors.New("runner is closing")
 )

--- a/internal/engine/clients/runner/options.go
+++ b/internal/engine/clients/runner/options.go
@@ -48,7 +48,7 @@ type RunOptions struct {
 	Image    string
 	Cmd      []string
 	Env      []string
-	Volumes  []string
+	Mounts   []map[string]string
 	Networks []string
 	Context  context.Context
 }
@@ -77,9 +77,9 @@ func RunWithEnv(env []string) RunOption {
 	}
 }
 
-func RunWithVolumes(volumes []string) RunOption {
+func RunWithMounts(mounts []map[string]string) RunOption {
 	return func(o *RunOptions) {
-		o.Volumes = volumes
+		o.Mounts = mounts
 	}
 }
 

--- a/internal/engine/services/coordinator/service.go
+++ b/internal/engine/services/coordinator/service.go
@@ -143,43 +143,18 @@ func (s *Service) RestartTask(ctx context.Context, id string) (*task.Task, error
 		return nil, task.ErrTaskNotRestartable
 	}
 
-	if len(t.Volumes) > 0 {
-		var cleanedVolumes []string
-		for _, v := range t.Volumes {
-			parts := strings.Split(v, ":")
-			if len(parts) == 2 {
-				cleanedVolumes = append(cleanedVolumes, parts[1])
-			} else {
-				cleanedVolumes = append(cleanedVolumes, v)
-			}
+	if len(t.Mounts) > 0 {
+		for _, m := range t.Mounts {
+			m.Source = ""
 		}
-		t.Volumes = cleanedVolumes
 	}
 
 	for _, pre := range t.Pre {
-		var cleanedPreVolumes []string
-		for _, v := range pre.Volumes {
-			parts := strings.Split(v, ":")
-			if len(parts) == 2 {
-				cleanedPreVolumes = append(cleanedPreVolumes, parts[1])
-			} else {
-				cleanedPreVolumes = append(cleanedPreVolumes, v)
-			}
-		}
-		pre.Volumes = cleanedPreVolumes
+		pre.Mounts = nil
 	}
 
 	for _, post := range t.Post {
-		var cleanedPostVolumes []string
-		for _, v := range post.Volumes {
-			parts := strings.Split(v, ":")
-			if len(parts) == 2 {
-				cleanedPostVolumes = append(cleanedPostVolumes, parts[1])
-			} else {
-				cleanedPostVolumes = append(cleanedPostVolumes, v)
-			}
-		}
-		post.Volumes = cleanedPostVolumes
+		post.Mounts = nil
 	}
 
 	now := time.Now()

--- a/internal/task/domain.go
+++ b/internal/task/domain.go
@@ -30,10 +30,15 @@ type Task struct {
 	Error       string     `json:"error,omitempty"`
 	Pre         []*Task    `json:"pre,omitempty"`
 	Post        []*Task    `json:"post,omitempty"`
-	Volumes     []string   `json:"volumes,omitempty"`
+	Mounts      []*Mount   `json:"mounts,omitempty"`
 	Networks    []string   `json:"networks,omitempty"`
 	Retry       *Retry     `json:"retry,omitempty"`
 	Timeout     string     `json:"timeout,omitempty"`
+}
+
+type Mount struct {
+	Source string `json:"source,omitempty"`
+	Target string `json:"target,omitempty"`
 }
 
 type Retry struct {

--- a/internal/task/errors.go
+++ b/internal/task/errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrTaskNotFound       = errors.New("task not found")
 	ErrMissingImage       = errors.New("task is missing image")
+	ErrMountMissingTarget = errors.New("mount missing target")
 	ErrAttemptsSpecified  = errors.New("may not specify retry attempts")
 	ErrExcessiveLimit     = errors.New("may not specify retry limit > 10")
 	ErrInvalidTimeout     = errors.New("invalid timeout")

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -19,6 +19,12 @@ func Factory(bs []byte) (*Task, error) {
 
 	// TODO: validate queue field
 
+	for _, m := range t.Mounts {
+		if m == nil || len(strings.TrimSpace(m.Target)) == 0 {
+			return nil, ErrMountMissingTarget
+		}
+	}
+
 	if t.Retry != nil {
 		if t.Retry.Attempts != 0 {
 			return nil, ErrAttemptsSpecified

--- a/tests/testdata/convert.json
+++ b/tests/testdata/convert.json
@@ -8,7 +8,7 @@
     "5",
     "/tmp/output.mp4"
   ],
-  "volumes": ["/tmp"],
+  "mounts": [{"target": "/tmp"}],
   "pre": [{
     "name": "download the remote file",
     "image": "alpine:3.18.3",


### PR DESCRIPTION
Refactors how container mounts (volumes) are managed within the system. Instead of relying on simple string representations, a new, more explicit `Mount` data structure is now used. This change enhances type safety, improves the clarity of mount configurations, makes the system easier to extend, and streamlines the underlying logic for volume management across various components.